### PR TITLE
Call conda mirror directly

### DIFF
--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -8,7 +8,6 @@ from pprint import pformat
 import requests
 import tqdm
 from collections import deque
-import fnmatch
 from conda_build.config import Config
 from conda_build.index import update_index
 

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -112,17 +112,6 @@ def not_blacklisted_license(package_names_to_mirror, upstream_repo_metadata,
             yield pkg
 
 
-def not_blacklisted_package(package_names_to_mirror, blacklist_packages):
-    logging.info("Checking that package names do not match "
-                 "blacklist_packages:")
-    logging.info(pformat(blacklist_packages))
-    for pkg in package_names_to_mirror:
-        matched = fnmatch.filter(blacklist_packages, pkg)
-        if matched:
-            logging.info("{} matches one of the blacklisted packages".format(pkg))
-            continue
-        yield pkg
-
 def main(upstream_channel, target_directory, platform, blacklist_packages):
     full_platform_list = copy.copy(platform)
     if 'all' in full_platform_list:
@@ -159,8 +148,6 @@ def main(upstream_channel, target_directory, platform, blacklist_packages):
                                              upstream_repo_packages)
         packages_to_mirror = not_blacklisted_license(packages_to_mirror,
                                                      upstream_repo_packages)
-        packages_to_mirror = not_blacklisted_package(packages_to_mirror,
-                                                     blacklist_packages)
 
         for idx, package in enumerate(packages_to_mirror):
             mirrored_packages.append((platform, package))

--- a/conda_mirror/conda_mirror.py
+++ b/conda_mirror/conda_mirror.py
@@ -64,12 +64,6 @@ def _make_arg_parser():
               " 'linux-64', 'linux-32', 'osx-64', 'win-32', 'win-64'}"),
         default=[],
     )
-    ap.add_argument(
-        '--blacklist-packages',
-        nargs="+",
-        help=("List of packages to blacklist. Separate with a space"),
-        default=[],
-    )
 
     return ap
 
@@ -80,7 +74,7 @@ def cli():
     if 'all' in args.platform and len(args.platform) != 1:
         logging.warning("If you pass 'all' as a platform option, all other "
                         "options will be ignored")
-    main(args.upstream_channel, args.target_directory, args.platform, args.blacklist_packages)
+    main(args.upstream_channel, args.target_directory, args.platform)
 
 
 def not_in_upstream(local_repo_metadata, upstream_repo_metadata):
@@ -112,7 +106,7 @@ def not_blacklisted_license(package_names_to_mirror, upstream_repo_metadata,
             yield pkg
 
 
-def main(upstream_channel, target_directory, platform, blacklist_packages):
+def main(upstream_channel, target_directory, platform):
     full_platform_list = copy.copy(platform)
     if 'all' in full_platform_list:
         full_platform_list.remove('all')

--- a/test/test_conda_mirror.py
+++ b/test/test_conda_mirror.py
@@ -65,7 +65,7 @@ def test_mirror_main(local_repo_root, platform, tmpdir):
         repodata_file = os.path.join(platform_dir, 'repodata.json')
         with open(repodata_file, 'w') as f:
             f.write("{}")
-        conda_mirror.main(channel, str(mirror_test_dir), [platform], blacklist_packages=[])
+        conda_mirror.main(channel, str(mirror_test_dir), [platform])
         # Make sure we mirror both files
         downloaded_files = os.listdir(platform_dir)
         assert "a-1-0.tar.bz2" in downloaded_files
@@ -78,7 +78,7 @@ def test_mirror_main(local_repo_root, platform, tmpdir):
 
         assert file_to_remove not in os.listdir(platform_dir)
 
-        conda_mirror.main(channel, str(mirror_test_dir), [platform], blacklist_packages=[])
+        conda_mirror.main(channel, str(mirror_test_dir), [platform])
 
         # Make sure we mirror both files
         downloaded_files = os.listdir(platform_dir)
@@ -100,11 +100,10 @@ def test_cli(local_repo_root, tmpdir):
                 f.write("{}")
 
         channel = os.path.basename(local_repo_root)
-        sys.argv = ['conda_mirror',
+        sys.argv = ['conda_mirror.py',
                     '--upstream-channel', channel,
                     '--target-directory', str(local_mirror),
-                    '--platform', 'all', 'linux-64',
-                   ]
+                    '--platform', 'all', 'linux-64']
 
         conda_mirror.cli()
 

--- a/test/test_conda_mirror.py
+++ b/test/test_conda_mirror.py
@@ -65,7 +65,7 @@ def test_mirror_main(local_repo_root, platform, tmpdir):
         repodata_file = os.path.join(platform_dir, 'repodata.json')
         with open(repodata_file, 'w') as f:
             f.write("{}")
-        conda_mirror.main(channel, str(mirror_test_dir), [platform])
+        conda_mirror.main(channel, str(mirror_test_dir), [platform], blacklist_packages=[])
         # Make sure we mirror both files
         downloaded_files = os.listdir(platform_dir)
         assert "a-1-0.tar.bz2" in downloaded_files
@@ -78,7 +78,7 @@ def test_mirror_main(local_repo_root, platform, tmpdir):
 
         assert file_to_remove not in os.listdir(platform_dir)
 
-        conda_mirror.main(channel, str(mirror_test_dir), [platform])
+        conda_mirror.main(channel, str(mirror_test_dir), [platform], blacklist_packages=[])
 
         # Make sure we mirror both files
         downloaded_files = os.listdir(platform_dir)
@@ -100,10 +100,11 @@ def test_cli(local_repo_root, tmpdir):
                 f.write("{}")
 
         channel = os.path.basename(local_repo_root)
-        sys.argv = ['conda_mirror.py',
+        sys.argv = ['conda_mirror',
                     '--upstream-channel', channel,
                     '--target-directory', str(local_mirror),
-                    '--platform', 'all', 'linux-64']
+                    '--platform', 'all', 'linux-64',
+                   ]
 
         conda_mirror.cli()
 


### PR DESCRIPTION
This avoids the check that conda does to disable mirroring anaconda.org/anaconda